### PR TITLE
definition.lisp - find-cobject-class-definitions: handle enums

### DIFF
--- a/definition.lisp
+++ b/definition.lisp
@@ -104,4 +104,6 @@
                      (cffi::foreign-pointer-type
                       `(cpointer ,(cobject-class-definition-class
                                    (find-cobject-class-definition (cffi::ensure-parsed-base-type (cffi-pointer-type type))))))
+                     (cffi::foreign-enum
+                      `(unsigned-byte ,(* (cffi:foreign-type-size (cffi::ensure-parsed-base-type :unsigned-int)))))
                      (t (error 'cobject-class-definition-not-found-error :type type))))))))


### PR DESCRIPTION
Hello, when trying to use claw with cffi-object I ran into two issues:., the first one to handle enums
consider
```
typedef enum {
    XOMOrientation_LTR_TTB,
    XOMOrientation_RTL_TTB,
    XOMOrientation_TTB_LTR,
    XOMOrientation_TTB_RTL,
    XOMOrientation_Context
} XOrientation;

typedef struct {
    int num_orientation;
    XOrientation *orientation;	/* Input Text description */
} XOMOrientation;

(cffi:defcenum (claw-cxx-xkb::|C:@EA@X-ORIENTATION| :unsigned-int)
               "/usr/include/X11/Xlib.h:1122:9"
               (:xom-orientation-ltr-ttb 0)
               (:xom-orientation-rtl-ttb 1)
               (:xom-orientation-ttb-ltr 2)
               (:xom-orientation-ttb-rtl 3)
               (:xom-orientation-context 4))

(cffi:defctype claw-cxx-xkb::x-orientation
               claw-cxx-xkb::|C:@EA@X-ORIENTATION|)

(cffi:defcstruct (claw-cxx-xkb::|C:@SA@XOM-ORIENTATION| :size 16)
                 (claw-cxx-xkb::num-orientation :int :offset 0)
                 (claw-cxx-xkb::orientation
                  (:pointer claw-cxx-xkb::x-orientation) :offset 8))

(cobj:define-struct-cobject-class claw-cxx-xkb::|C:@SA@XOM-ORIENTATION|)
```

The proposed patch intends fix the last form
 from blowing up.